### PR TITLE
Prototype of Reaction Interface for Post Detail

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -10,6 +10,7 @@ import { PostProvider } from "./post/PostProvider";
 import { SubbedPosts } from "./post/SubbedPosts";
 import { PostReactionProvider } from "./postReaction/PostReactionProvdier";
 import { ReactionBox } from "./reaction/ReactionBox";
+import { ReactionInterface } from "./reaction/ReactionInterface";
 import { ReactionProvider } from "./reaction/ReactionProvider";
 import { UserProvider } from "./user/UserProvider";
 
@@ -51,6 +52,7 @@ export const ApplicationViews = () => {
                     </Route>
                     <Route exact path="/reactions">
                       <ReactionBox />
+                      <ReactionInterface />
                     </Route>
               </ReactionProvider>
             </PostReactionProvider>

--- a/src/components/reaction/ReactionInterface.js
+++ b/src/components/reaction/ReactionInterface.js
@@ -39,23 +39,7 @@ export const ReactionInterface = (post) => {
             setLocalPost(data)})
     }, [])
     
-    useEffect(() => {
-        const post_reactions = localPost.reactions
-        let reaction_counter = {}
-        debugger
-        for (let i = 0; i < reactions.length; i++) {
-            for (let n = 0; n < post_reactions.length; n++) {
-                if (reactions[i].id === post_reactions[n].id) {
-                    if (reaction_counter[reactions[i].id] == NaN) {
-                        reaction_counter[reactions[i].id] = 1;
-                    } else {
-                        reaction_counter[reactions[i].id] = reaction_counter[reactions[i].id] + 1;
-                    }
-                }
-            }
-        }
-        console.log(reaction_counter)
-    }, [localPost])
+    console.log(localPost)
 
     return (
         <>
@@ -65,9 +49,10 @@ export const ReactionInterface = (post) => {
             {
                 reactions.map(reactObj => (
                     <>
-                    <button className="reaction_button">
-                        <img className="reaction_image" src={reactObj.image_url} alt={reactObj.label} width="15" height="15"/>
-                    </button>
+                        <button className="reaction_button">
+                            <img className="reaction_image" src={reactObj.image_url} alt={reactObj.label} width="15" height="15"/>
+                        </button>
+                        
                     </>
                 ))
             }

--- a/src/components/reaction/ReactionInterface.js
+++ b/src/components/reaction/ReactionInterface.js
@@ -1,0 +1,77 @@
+import React, { useContext, useEffect, useState } from 'react';
+import { PostContext } from '../post/PostProvider';
+import { ReactionContext } from "./ReactionProvider";
+import "./reaction_interface.css";
+
+const post = [{
+    "id": 1,
+    "rare_user": {
+        "id": 1,
+        "user": {
+            "first_name": "Steve",
+            "last_name": "Brownlee",
+            "username": "me@me.com"
+        }
+    },
+    "category": {
+        "id": 1,
+        "label": "News"
+    },
+    "title": "Cassowary",
+    "publication_date": "2021-07-07",
+    "image_url": "https://www.guinnessworldrecords.com/Images/cassowary-side_tcm25-568936.jpg",
+    "content": "cool bird",
+    "approved": true,
+    "isMine": true
+}]
+
+export const ReactionInterface = (post) => {
+    const { reactions, getAllReactions} = useContext(ReactionContext)
+    const { getPostById } = useContext(PostContext)
+    const [ localPost, setLocalPost ] = useState({})
+
+    useEffect(() => {
+        getAllReactions()
+    }, [])
+
+    useEffect(() => {
+        getPostById(1).then((data) => {
+            setLocalPost(data)})
+    }, [])
+    
+    useEffect(() => {
+        const post_reactions = localPost.reactions
+        let reaction_counter = {}
+        debugger
+        for (let i = 0; i < reactions.length; i++) {
+            for (let n = 0; n < post_reactions.length; n++) {
+                if (reactions[i].id === post_reactions[n].id) {
+                    if (reaction_counter[reactions[i].id] == NaN) {
+                        reaction_counter[reactions[i].id] = 1;
+                    } else {
+                        reaction_counter[reactions[i].id] = reaction_counter[reactions[i].id] + 1;
+                    }
+                }
+            }
+        }
+        console.log(reaction_counter)
+    }, [localPost])
+
+    return (
+        <>
+        <h1>Example Reaction Interface (for Individual Post)</h1>
+        
+        <div className="reaction_interface_outline">
+            {
+                reactions.map(reactObj => (
+                    <>
+                    <button className="reaction_button">
+                        <img className="reaction_image" src={reactObj.image_url} alt={reactObj.label} width="15" height="15"/>
+                    </button>
+                    </>
+                ))
+            }
+        </div>
+        </>
+    )
+}

--- a/src/components/reaction/ReactionInterface.js
+++ b/src/components/reaction/ReactionInterface.js
@@ -15,10 +15,9 @@ export const ReactionInterface = (post) => {
 
     useEffect(() => {
         getPostById(1).then((data) => {
-            setLocalPost(data)})
-    }, [])
-    
-    console.log(localPost)
+            setLocalPost(data.reaction_counter)})
+        }, [])
+        
 
     return (
         <>
@@ -30,8 +29,8 @@ export const ReactionInterface = (post) => {
                     <>
                         <button className="reaction_button">
                             <img className="reaction_image" src={reactObj.image_url} alt={reactObj.label} width="15" height="15"/>
+                            <div className="reaction_count">{localPost[reactObj.id]?.count}</div>
                         </button>
-                        
                     </>
                 ))
             }

--- a/src/components/reaction/ReactionInterface.js
+++ b/src/components/reaction/ReactionInterface.js
@@ -3,27 +3,6 @@ import { PostContext } from '../post/PostProvider';
 import { ReactionContext } from "./ReactionProvider";
 import "./reaction_interface.css";
 
-const post = [{
-    "id": 1,
-    "rare_user": {
-        "id": 1,
-        "user": {
-            "first_name": "Steve",
-            "last_name": "Brownlee",
-            "username": "me@me.com"
-        }
-    },
-    "category": {
-        "id": 1,
-        "label": "News"
-    },
-    "title": "Cassowary",
-    "publication_date": "2021-07-07",
-    "image_url": "https://www.guinnessworldrecords.com/Images/cassowary-side_tcm25-568936.jpg",
-    "content": "cool bird",
-    "approved": true,
-    "isMine": true
-}]
 
 export const ReactionInterface = (post) => {
     const { reactions, getAllReactions} = useContext(ReactionContext)

--- a/src/components/reaction/reaction_interface.css
+++ b/src/components/reaction/reaction_interface.css
@@ -11,4 +11,6 @@
     margin: 0rem 1rem;
     border: none;
     background-color: white;
+    display: flex;
+    flex-flow: row wrap;
 }

--- a/src/components/reaction/reaction_interface.css
+++ b/src/components/reaction/reaction_interface.css
@@ -1,0 +1,14 @@
+.reaction_interface_outline {
+    border: 1px black solid;
+    border-radius: 10px;
+    margin: 2rem .5rem;
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: space-around;
+}
+
+.reaction_button {
+    margin: 0rem 1rem;
+    border: none;
+    background-color: white;
+}


### PR DESCRIPTION
## Changes made
Added `ReactionInterface.js` and modified `ApplicationViews` to render module

Within "Reaction Manager", there now is an example component that renders a prototype of a reaction box, associated with a fetch call to `posts/1`. Might need to be adapted tomorrow to a slightly different form.

> Note: This is just an example. Not part of the wireframe.